### PR TITLE
Fixed require path in typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,2 @@
-const {ReflexContainer, ReflexSplitter, ReflexElement} = require('./src/lib');
+const {ReflexContainer, ReflexSplitter, ReflexElement} = require('./dist/umd/react-reflex.min');
 export { ReflexContainer, ReflexSplitter, ReflexElement };


### PR DESCRIPTION
Also, the file `index.d.ts` is not being include in your NPM package when you upload a new package.  The package extracted from npmjs is missing this file, so the typings can't be used.  The `package.json` is already setup to use this file (the "types" key), but it doesn't work because the actual file it references is not there.