### PR TITLE
Adding option to not propagate height/width to ReflexElement child

### DIFF
--- a/src/lib/ReflexElement.jsx
+++ b/src/lib/ReflexElement.jsx
@@ -21,6 +21,8 @@ export default class ReflexElement extends React.Component {
     renderOnResizeRate: PropTypes.number,
     propagateDimensions: PropTypes.bool,
     renderOnResize: PropTypes.bool,
+    resizeHeight: PropTypes.bool, 
+    resizeWidth: PropTypes.bool,
     className: PropTypes.string
   }
 
@@ -31,6 +33,8 @@ export default class ReflexElement extends React.Component {
   static defaultProps = {
     renderOnResize: Browser.isSafari(),
     propagateDimensions: false,
+    resizeHeight: true, 
+    resizeWidth: true,
     renderOnResizeRate: 60,
     className: ''
   }
@@ -92,13 +96,13 @@ export default class ReflexElement extends React.Component {
   //
   /////////////////////////////////////////////////////////
   onResize (rect) {
-
-    if (this.props.renderOnResize) {
+    const { renderOnResize, resizeHeight, resizeWidth} = this.props
+    if (renderOnResize) {
 
       this.setStateThrottled({
         dimensions: {
-          height: Math.floor(rect.bounds.height),
-          width: Math.floor(rect.bounds.width)
+          ...resizeHeight && {height: Math.floor(rect.bounds.height)},
+          ...resizeWidth && {width: Math.floor(rect.bounds.width)}
         }
       })
     }


### PR DESCRIPTION
I was having an issue where I wanted the width of my components to be automatically updated, but not the height so I added some code to allow me to do that. Namely resizeHeight and resizeWidth booleans.

I'm using a fork of this repo with these changes and it fixes the issue I was seeing with the height. 
https://www.npmjs.com/package/tg-react-reflex

I wasn't quite sure how to update the documentation to show these new options so I thought I'd ask for your help doing so. 

Thanks! 

Love this repo btw