### PR TITLE
Spread attributes for Re-Flex components

### DIFF
--- a/src/lib/ReflexContainer.js
+++ b/src/lib/ReflexContainer.js
@@ -883,7 +883,9 @@ export default class ReflexContainer extends React.Component {
       })
 
     return (
-      <div className={className}
+      <div
+        {...this.props}
+        className={className}
         style={this.props.style}>
         { this.children }
       </div>

--- a/src/lib/ReflexElement.js
+++ b/src/lib/ReflexElement.js
@@ -235,7 +235,10 @@ export default class ReflexElement extends React.Component {
     }
 
     return (
-      <div className={className} style={style}>
+      <div
+        {...this.props}
+        className={className}
+        style={style}>
       {
         this.props.propagateDimensions
           ? <SizeAwareReflexElement {...this.props}/>

--- a/src/lib/ReflexHandle.js
+++ b/src/lib/ReflexHandle.js
@@ -235,7 +235,8 @@ export default class ReflexHandle extends React.Component {
     ].join(' ')
 
     return (
-      <div 
+      <div
+        {...this.props}
         onTouchStart={this.onMouseDown}
         onMouseDown={this.onMouseDown}
         style={this.props.style}

--- a/src/lib/ReflexSplitter.js
+++ b/src/lib/ReflexSplitter.js
@@ -235,7 +235,8 @@ export default class ReflexSplitter extends React.Component {
     ].join(' ')
 
     return (
-      <div 
+      <div
+        {...this.props}
         onTouchStart={this.onMouseDown}
         onMouseDown={this.onMouseDown}
         style={this.props.style}


### PR DESCRIPTION
Fixes #76 Data attributes are removed from Re-Flex components

The spreaded props are added before the className prop, otherwise the calculated class name would get overridden.

Everything in the demo still works!

![image](https://user-images.githubusercontent.com/6274717/59553074-bd2bb700-8f5d-11e9-8771-da95df372ec8.png)
