### PR TITLE
Update flex type

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -28,7 +28,7 @@ export type ReflexElementProps = {
     size?: number;
     minSize?: number;
     maxSize?: number;
-    flex?: number;
+    flex?: number | string;
     direction?: PosNeg | [PosNeg, PosNeg];
     onStartResize?: (args: HandlerProps) => void;
     onStopResize?: (args: HandlerProps) => void;


### PR DESCRIPTION
flex should accept type string and works fine.  

At the moment we bypass this type using the following `flex={('0.45' as unknown) as number}`