### PR TITLE
fix(ReflexContainer): Avoid findDOMNode on unmounted component

### DIFF
--- a/src/lib/ReflexContainer.js
+++ b/src/lib/ReflexContainer.js
@@ -56,6 +56,7 @@ export default class ReflexContainer extends React.Component {
     this.state = {
       flexData: []
     }
+    this.ref = React.createRef()
   }
 
   /////////////////////////////////////////////////////////
@@ -99,10 +100,8 @@ export default class ReflexContainer extends React.Component {
 
     this.events.off()
 
-    if (this.state.windowResizeAware) {
-      window.removeEventListener(
-        'resize', this.onWindowResize)
-    }
+    window.removeEventListener(
+      'resize', this.onWindowResize)
   }
 
   /////////////////////////////////////////////////////////
@@ -582,35 +581,37 @@ export default class ReflexContainer extends React.Component {
   //
   /////////////////////////////////////////////////////////
   computePixelFlex (orientation = this.props.orientation) {
-
-    const domElement = ReactDOM.findDOMNode(this)
+    if (!this.ref.current) {
+      console.warn('Unable to locate ReflexContainer dom node');
+      return 0.0;
+    }
 
     switch (orientation) {
 
       case 'horizontal':
 
-        if (domElement.offsetHeight === 0.0) {
+        if (this.ref.current.offsetHeight === 0.0) {
           console.warn(
             'Found ReflexContainer with height=0, ' +
             'this will cause invalid behavior...')
-          console.warn(domElement)
+          console.warn(this.ref.current)
           return 0.0
         }
 
-        return 1.0 / domElement.offsetHeight
+        return 1.0 / this.ref.current.offsetHeight
 
       case 'vertical':
       default:
 
-        if (domElement.offsetWidth === 0.0) {
+        if (this.ref.current.offsetWidth === 0.0) {
           console.warn(
             'Found ReflexContainer with width=0, ' +
             'this will cause invalid behavior...')
-          console.warn(domElement)
+          console.warn(this.ref.current)
           return 0.0
         }
 
-        return 1.0 / domElement.offsetWidth
+        return 1.0 / this.ref.current.offsetWidth
     }
   }
 
@@ -921,7 +922,8 @@ export default class ReflexContainer extends React.Component {
       <div
         {...getDataProps(this.props)}
         style={this.props.style}
-        className={className}>
+        className={className}
+        ref={this.ref}>
         { this.children }
       </div>
     )


### PR DESCRIPTION
## Issue
Resizing a window that includes `ReflexContainer` results in a runtime error with the message "Unable to find node on an unmounted component."

## Changes
* Removes `findDOMNode` usage on `ReflexContainer`, replacing with a custom ref on `ReflexContainer`. This is in accordance with the suggestion from React here: https://reactjs.org/docs/react-dom.html#finddomnode
* Ensures that the window resize listener is removed when the component is unmounted. This avoids setting state on the unmounted component.
