### PR TITLE
Fix a problem with the flex styles of reflex elements in IE11

### DIFF
--- a/src/lib/ReflexElement.js
+++ b/src/lib/ReflexElement.js
@@ -125,7 +125,7 @@ export default class ReflexElement extends React.Component {
   /////////////////////////////////////////////////////////
   static defaultProps = {
     propagateDimensionsRate: 100,
-    propagateDimensions: false, 
+    propagateDimensions: false,
     resizeHeight: true,
     resizeWidth: true,
     direction: [1],
@@ -185,7 +185,7 @@ export default class ReflexElement extends React.Component {
   toArray (obj) {
     return obj ? (Array.isArray(obj) ? obj : [obj]) : []
   }
-  
+
   /////////////////////////////////////////////////////////
   //
   //
@@ -221,7 +221,9 @@ export default class ReflexElement extends React.Component {
 
     const style = {
       ...this.props.style,
-      flex: this.props.flex
+      flexGrow: this.props.flex,
+      flexShrink: 1,
+      flexBasis: '0%'
     }
 
     return (
@@ -235,6 +237,6 @@ export default class ReflexElement extends React.Component {
           : this.renderChildren()
       }
       </div>
-    ) 
+    )
   }
 }


### PR DESCRIPTION
### Issue
I got a problem with the flex styles of reflex elements in IE11. When I pass size to that it renders strange. The library computes proper flex value, but after rendering it changes to some _magic_ value which not equals expected.

### Changes
Pass `flex-grow`, `flex-shrink` and `flex-basis` by individual properties instead of short `flex` declaration. That way provides correct rendering of reflex element styles in IE11