### PR TITLE
fix:flex data is not updated when different flex value is passed as property.

### DIFF
--- a/src/lib/ReflexContainer.js
+++ b/src/lib/ReflexContainer.js
@@ -125,8 +125,8 @@ export default class ReflexContainer extends React.Component {
     const children = this.getValidChildren(this.props)
 
     if ((children.length !== this.state.flexData.length) ||
-        (this.props.orientation !== this.props.orientation) || 
-        this.flexHasChanged(this.props)) {
+        (prevProps.orientation !== this.props.orientation) || 
+        this.flexHasChanged(prevProps)) {
 
       const flexData = this.computeFlexData(
         children, this.props)
@@ -189,10 +189,10 @@ export default class ReflexContainer extends React.Component {
   // to one or several children
   //
   /////////////////////////////////////////////////////////
-  flexHasChanged (props) {
+  flexHasChanged (prevProps) {
 
-    const nextChildrenFlex =
-      this.getValidChildren(props).map((child) => {
+    const prevChildrenFlex =
+      this.getValidChildren(prevProps).map((child) => {
         return child.props.flex || 0
       })
 
@@ -202,7 +202,7 @@ export default class ReflexContainer extends React.Component {
       })
 
     return !childrenFlex.every((flex, idx) => {
-      return flex === nextChildrenFlex[idx]
+      return flex === prevChildrenFlex[idx]
     })
   }
 


### PR DESCRIPTION
Summary:
flex data does not get updated in `ComponentDidMount()` because `flexHasChanged()` always returns false in [ReflexContainer.js](https://github.com/leefsmp/Re-Flex/blob/3e707ff5fce4ee52a396d74c583dc1ee3ebb0a60/src/lib/ReflexContainer.js#L192). 

This is because it compares `this.props` with props(which is actually the same i.e., this.props). I have changed it to compare `prevProps` with currentProps(this.props).