### PR TITLE
Fix demo minSize and maxSize type

### DIFF
--- a/src/demo/demo.jsx
+++ b/src/demo/demo.jsx
@@ -69,8 +69,8 @@ class ReflexBasicSplitterDemo
         <ReflexSplitter/>
 
         <ReflexElement className="right-pane"
-          minSize="200"
-          maxSize="800">
+          minSize={200}
+          maxSize={800}>
           <div className="pane-content">
             <label>
               Right Pane (resizable)
@@ -112,8 +112,8 @@ class ReflexSplitterPropagationDemo2x
         <ReflexSplitter propagate={true}/>
 
         <ReflexElement className="middle-pane"
-          minSize="200"
-          maxSize="800">
+          minSize={200}
+          maxSize={800}>
           <div className="pane-content">
             <label>
               Middle Pane (resizable)


### PR DESCRIPTION
# Problem

If we run the demo, we get an error with tsserver due to the type definition of `minSize` and `maxSize` in the `index.d.ts` file.

Also this mentions that number should be preferred.
https://github.com/leefsmp/Re-Flex/issues/95

# index.d.ts
```
  export type ReflexElementProps = {
      propagateDimensions?: boolean;
      propagateDimensionsRate?: number;
      resizeHeight?: boolean;
      resizeWidth?: boolean;
      size?: number;
      minSize?: number;
      maxSize?: number;
      flex?: number;
      direction?: PosNeg | [PosNeg, PosNeg];
      onStartResize?: (args: HandlerProps) => void;
      onStopResize?: (args: HandlerProps) => void;
      onResize?: (args: HandlerProps) => void;
  } & StyleAndClass;
```

# Solution

Change `minSize="200" to minSize={200}` for all instances in the `demo.jsx` file

# Error

The error looks like this:
```
  maxSize='800 [tsserver 2769] [E] No overload matches this call.
>                Overload 2 of 2, '(props: ReflexElementProps, context: any):
  <div classNa ReflexElement', gave the following error.
    <Sidebar o     Type 'string' is not assignable to type 'number | undefined'.
  </div>         Overload 2 of 2, '(props: ReflexElementProps, context: any):
</ReflexElemen ReflexElement', gave the following error.
<ReflexSplitte     Type 'string' is not assignable to type 'number | undefined'.
```
