### PR TITLE
Bug: programmatically set size results in different flexGrow #147

### DIFF
--- a/src/lib/ReflexContainer.js
+++ b/src/lib/ReflexContainer.js
@@ -369,6 +369,8 @@ export default class ReflexContainer extends React.Component {
           this.computeAvailableOffset(
             splitterIdx, dir * offset)
 
+        this.state.isSetPropSize = data.isSetPropSize
+
         this.elements = null
 
         if (availableOffset) {
@@ -390,6 +392,7 @@ export default class ReflexContainer extends React.Component {
         // TODO handle exception ...
         console.log(ex)
       }
+      delete this.state.isSetPropSize
     })
   }
 
@@ -595,7 +598,7 @@ export default class ReflexContainer extends React.Component {
 
     const newSize = Math.max(size + offset, 0)
 
-    const currentFlex = this.state.flexData[idx].flex
+    const currentFlex = this.state.isSetPropSize ? 0 : this.state.flexData[idx].flex
 
     const newFlex = (currentFlex > 0)
         ? currentFlex * newSize / size

--- a/src/lib/ReflexElement.js
+++ b/src/lib/ReflexElement.js
@@ -141,7 +141,8 @@ class ReflexElement extends React.Component {
         await this.props.events.emit('element.size', {
           index: this.props.index,
           size: this.props.size,
-          direction
+          direction,
+          isSetPropSize: true
         })
       }
     }


### PR DESCRIPTION
I modified ReflexElement.js and ReflexContainer.js to not do relative calculations if prop.size changes.